### PR TITLE
fixed address bug

### DIFF
--- a/components/contract-address.tsx
+++ b/components/contract-address.tsx
@@ -21,10 +21,6 @@ export default function ContractAddress() {
     }
   }, [savedContractAddresses]);
 
-  useEffect(() => {
-    get(contractAddressName).then((val) => setContractAddress(val))
-  }, [contractAddressName, searchParams])
-
   function handleInputContractAddressChange(e: React.ChangeEvent<HTMLInputElement>) {
     setContractAddress(e.target.value)
   }


### PR DESCRIPTION
There is a address bug during address input. If the address name is the same as ABI name, the input box will render the abi content.

This PR fixes this bug by removing the useEffect hook causing it.